### PR TITLE
Fix template-breaking bug

### DIFF
--- a/fpc.py
+++ b/fpc.py
@@ -572,7 +572,7 @@ class Candidate():
         fn_al = self.fileName(alternative=True)  # Alternative filename
         # We add the com-nom parameter if the original filename
         # differs from the alternative filename.
-        comnom = "|com-nom=%s" % fn_or if fn_or != fn_al else ""
+        comnom = "|com-nom=%s" % fn_or.replace("File:", "") if fn_or != fn_al else ""
 
         # First check if there already is an assessments template on the page
         params = re.search(AssR,old_text)


### PR DESCRIPTION
See https://commons.wikimedia.org/w/index.php?title=File:Quarry_in_Makhtesh_Ramon_bw_(50771).jpg&diff=240078945&oldid=239061901. This should remove "File:" which breaks the template.