### PR TITLE
Support set, add assessment below the location templates if exist and short closing template

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ FPCBot
 
 Bot that handles the FPC process at wikimedia commons.
 
-Some more info at: http://commons.wikimedia.org/wiki/User:FPCBot
+Some more info at: <http://commons.wikimedia.org/wiki/User:FPCBot>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+certifi==2019.11.28
+chardet==3.0.4
+idna==2.9
+mwparserfromhell==0.5.4
+pbr==5.4.4
+pkg-resources==0.0.0
+pycparser==2.19
+pywikibot==3.0.20200111
+requests==2.23.0
+six==1.14.0
+tendo==0.2.15
+urllib3==1.25.8

--- a/todo.txt
+++ b/todo.txt
@@ -1,4 +1,3 @@
-
 This file will just contain some short notes about things to fix or
 features that could be implemented.
 
@@ -9,7 +8,4 @@ assigned to one single author - Look in old logs for duplicate votes
   
 * Implementation: - Look for the next signature following a vote. This
 can also be used to raise a warning about unsigned votes.  - Should
-also look whether a vote comes from a logged in account
-
-== Fix notification template for candidates with multi-candidates ==
-
+also look whether a vote comes from a logged in account.


### PR DESCRIPTION
- Fixed issues with set nomination. (example below)

1. [gallery promotion on nominator's talk-page](https://commons.wikimedia.org/w/index.php?title=User_talk:Eatcha&diff=401632087&oldid=401632031)

2. [Add the first image with note : NUMBER ''''''SET_NAME''' - a set of NUMBER_OF_FILES files''' ](https://commons.wikimedia.org/w/index.php?title=Commons:Featured_pictures/chronological/March_2020&diff=401862950&oldid=401862537)

3. [Add first image to Commons:Featured pictures, list . We can't add all because there's a max limit of 4 files.](https://commons.wikimedia.org/w/index.php?title=Commons:Featured_pictures,_list&diff=401631862&oldid=401631793)

4. [Add Assessments template with com-nom, add below the location template](https://commons.wikimedia.org/w/index.php?title=File:Rana_arvalis_%C3%A0_la_surface_de_l%27eau_au_parc_national_des_C%C3%A9vennes_pr%C3%A8s_d%27Anduze_(2).tif&diff=401631921&oldid=385326356)

5. [Notify uploader of all images in a set, even if all files are uploaded by different users.](https://commons.wikimedia.org/w/index.php?title=User_talk:Madenhacker&diff=401632306&oldid=401630331)

- The closing templates are changed.

1. changed to `{{FPC-results-unreviewed}}`  from `{{FPC-results-ready-for-review}}`. why ? It's easier to remove "un" than changing the older template. 

- Add assessment below the location templates.

1. supported templates are {{Location}} and {{Object location}}, usage 13_019_937 (13M) and 3_476_468 (3.5M) files respectively. 