### PR TITLE
Fix and simplify Candidate.findGalleryOfFile()

### DIFF
--- a/fpc.py
+++ b/fpc.py
@@ -145,20 +145,19 @@ class Candidate:
         return filesList
 
     def findGalleryOfFile(self):
-        """Try to find Gallery in the nomination page to make closing users life easier."""
+        """
+        Try to find the gallery link in the nomination subpage
+        in order to make the life of the closing users easier.
+        """
         text = self.page.get(get_redirect=True)
-        RegexGallery = re.compile(
-            r"(?:.*)Gallery(?:.*)(?:\s.*)\[\[Commons\:Featured[_ ]pictures\/([^\]]{1,180})"
+        match = re.search(
+            r"Gallery[^\n]+\[\[Commons:Featured[_ ]pictures\/([^\n\]]+)",
+            text,
         )
-        matches = RegexGallery.finditer(text)
-        for m in matches:
-            Gallery = m.group(1)
-        try:
-            Gallery
-        except Exception:
-            Gallery = ""
-
-        return Gallery
+        if match is not None:
+            return match.group(1)
+        else:
+            return ""
 
     def countVotes(self):
         """


### PR DESCRIPTION
The current implementation of `Candidate.findGalleryOfFile()` is unnecessarily complicated.  And it contains a bug: under certain circumstances it returns a wrong gallery link. This has happened e.g. here:

https://commons.wikimedia.org/wiki/Commons:Featured_picture_candidates/File:Partial_solar_eclipse_with_some_clouds_in_Tuntorp_43.jpg

The gallery link is correctly stated as “Astronomy#Eclipse”, but when the bot closed the nomination and added the `{{FPC-results-unreviewed}}` template, it used the gallery link “Photo techniques/Composites and Montages#Sequences (Chronological)”. Many thanks to Wikimedia Commons user W.carter for noticing and reporting this problem!

Why did this happen?  The regular expression in the method does not just search for the first valid gallery link right after the first occurrence of the word “Gallery” (as one would have expected), it searches for *all* links beginning with `[[Commons:Featured[_ ]pictures/` after the word “Gallery”.  In the cited nomination three links match this pattern.  The current code always returns the last one of all links it can find; that’s wrong because the correct gallery link is normally the very first one on every nomination subpage.

We can fix this bug and simplify the code of the method significantly if we assume that the correct gallery link should be the first link with starts with `[[Commons:Featured[_ ]pictures/` and appears on the same line after the first occurrence of the word “Gallery”. All well-formed nomination subpages fulfill this condition.

I have written a little test script which parses the Wikitext of all 627 nomination subpages which were created from January to April 2025 both with the old code and with the new one.  The gallery link as found by the old code was wrong in 4 cases and incomplete (without section anchor) in 1 case. The results of the new code were correct in all these cases.