### PR TITLE
Make implicit default return value explicit

### DIFF
--- a/fpc.py
+++ b/fpc.py
@@ -207,6 +207,9 @@ class Candidate:
         if self._pro >= 10 and self._con == 0:
             return True
 
+        # If we arrive here, no rule applies.
+        return False
+
     def closePage(self):
         """
         Will add the voting results to the page if it is finished.


### PR DESCRIPTION
`Candidate.rulesOfFifthDay()`: Make explicit that the return value of this method is `False` if not a single condition is met. This avoids misunderstandings and helps new developers to understand the code more easily.

(Actually the implicit default return value was `None`, but it’s more consistent to return `False` here because the code which calls this method expects a boolean value anyway.)