### PR TITLE
Remove unused entry from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-mwparserfromhell
 pywikibot


### PR DESCRIPTION
The file `requirements.txt` lists also the `mwparserfromhell` package, but I cannot find any reference to it in the code. Wrong requirements entries are misleading, so let’s remove this.

We import the `pywikibot` package which in turn imports `mwparserfromhell`.  But we do not import the latter ourselves, and so we do not need to require that package.  We do not list all the other packages which are imported by `pywikibot` as requirements, so why should we list `mwparserfromhell` as long as we do not reference it in the FPCBot code?

Of course I may be wrong. If you can find an explicit reference to `mwparserfromhell` somewhere in the code, I beg your pardon! Then please just close this pull request.