### PR TITLE
Fix and simplify Candidate.findGalleryOfFile()

### DIFF
--- a/fpc.py
+++ b/fpc.py
@@ -145,20 +145,19 @@ class Candidate:
         return filesList
 
     def findGalleryOfFile(self):
-        """Try to find Gallery in the nomination page to make closing users life easier."""
+        """
+        Try to find the gallery link in the nomination subpage
+        in order to make the life of the closing users easier.
+        """
         text = self.page.get(get_redirect=True)
-        RegexGallery = re.compile(
-            r"(?:.*)Gallery(?:.*)(?:\s.*)\[\[Commons\:Featured[_ ]pictures\/([^\]]{1,180})"
+        match = re.search(
+            r"Gallery[^\n]+?\[\[Commons:Featured[_ ]pictures\/([^\n\]]+)",
+            text,
         )
-        matches = RegexGallery.finditer(text)
-        for m in matches:
-            Gallery = m.group(1)
-        try:
-            Gallery
-        except Exception:
-            Gallery = ""
-
-        return Gallery
+        if match is not None:
+            return match.group(1)
+        else:
+            return ""
 
     def countVotes(self):
         """


### PR DESCRIPTION
Under certain circumstances the method `Candidate.findGalleryOfFile()` returns a wrong gallery link.  This has happened e.g. [in this nomination](https://commons.wikimedia.org/wiki/Commons:Featured_picture_candidates/File:Partial_solar_eclipse_with_some_clouds_in_Tuntorp_43.jpg).  The gallery link is correctly stated as “Astronomy#Eclipse”, but when the bot closed the nomination and added the `{{FPC-results-unreviewed}}` template, it used the gallery link “Photo techniques/Composites and Montages#Sequences (Chronological)”.  Many thanks to Wikimedia Commons user [W.carter](https://commons.wikimedia.org/wiki/User:W.carter) for noticing and reporting this problem!

Why did this happen?  The code of the method does not just search for the first valid gallery link right after the first occurrence of the word “Gallery” (as one would have expected), it searches for *all* links beginning with `[[Commons\:Featured[_ ]pictures/` after the word “Gallery”.  In the cited nomination three links match this pattern.  The current code always returns the last one of all links it can find; that’s wrong because the correct gallery link is normally the very first one on every nomination subpage.

This is not an academic question, but a real problem.  If `Candidate.findGalleryOfFile()` returns a wrong gallery link, the bot will add that wrong gallery link to the `{{FPC-results-unreviewed}}` template.  Either the closing user notices this in time and corrects it (like e.g. here [here](https://commons.wikimedia.org/w/index.php?title=Commons:Featured_picture_candidates/File:Partial_solar_eclipse_with_some_clouds_in_Tuntorp_43.jpg&diff=next&oldid=1019740691) or [there](https://commons.wikimedia.org/w/index.php?title=Commons:Featured_picture_candidates/File:Woningen_boven_S-charl,_12-10-2024._(actm.)_01.jpg&diff=prev&oldid=1006693288)), or the glitch goes unnoticed and the bot sorts the new FP into the wrong gallery page or section, so users must manually correct this later (like e.g. [here](https://commons.wikimedia.org/w/index.php?title=Commons:Featured_pictures/Objects/Monetary_items&diff=prev&oldid=1020750389)).  In any case every wrong result of `Candidate.findGalleryOfFile()` urges users to intervene manually.

We can fix this bug and simplify the code of the method significantly if we assume that the correct gallery link should be the first link with starts with `[[Commons:Featured[_ ]pictures/` and appears on the same line after the first occurrence of the word “Gallery”.  All well-formed nomination subpages fulfill this condition.  This allows us to streamline the regex drastically and to drop the loop (because we have at most a single regex match now).  At this opportunity let’s also replace the quite unusual use of `try: ... except: ...` by a simple and clear `if ...: else: ...`.

I have written a little test script which parses the Wikitext of all 627 nomination subpages which were created from January to April 2025 both with the old code and with the new one.  The gallery link as found by the old code was wrong in 4 cases and incomplete (without section anchor) in 1 case.  The results of the new code were correct in all these cases.