### PR TITLE
Fix and simplify Candidate.addAssessments()

### DIFF
--- a/fpc.py
+++ b/fpc.py
@@ -720,7 +720,7 @@ class Candidate:
             page = pywikibot.Page(G_Site, file)
             current_page = page
             old_text = page.get(get_redirect=True)
-            AssR = re.compile(r"{{\s*[Aa]ssessments\s*\|(.*)}}")
+            AssR = re.compile(r"\{\{\s*[Aa]ssessments\s*(\|.*?)\}\}")
             fn_or = self.fileName(alternative=False)  # Original filename
             fn_al = self.fileName(alternative=True)  # Alternative filename
             # We add the com-nom parameter if the original filename
@@ -772,7 +772,7 @@ class Candidate:
                     + old_text[end:]
                 )
                 # new_text = re.sub(r'({{\s*[Ii]nformation)',r'{{Assessments|featured=1}}\n\1',old_text)
-                self.commit(old_text, new_text, current_page, "FPC promotion")
+            self.commit(old_text, new_text, current_page, "FPC promotion")
 
     def addToCurrentMonth(self):
         """

--- a/fpc.py
+++ b/fpc.py
@@ -713,11 +713,11 @@ class Candidate:
             files = self.setFiles()
         else:
             files = [self.fileName()]
+        AssR = re.compile(r"\{\{\s*[Aa]ssessments\s*(\|.*?)\}\}")
         for file in files:
             page = pywikibot.Page(G_Site, file)
             current_page = page
             old_text = page.get(get_redirect=True)
-            AssR = re.compile(r"\{\{\s*[Aa]ssessments\s*(\|.*?)\}\}")
             fn_or = self.fileName(alternative=False)  # Original filename
             fn_al = self.fileName(alternative=True)  # Alternative filename
             # We add the com-nom parameter if the original filename


### PR DESCRIPTION
### Fix two bugs and two potential issues in the code of `Candidate.addAssessments()`

1. When an image with a description page that already contains the `{{Assessments}}` template (e.g. because the image is featured on some Wikipedia) is promoted to FP status, the bot always fails to add the parameter `featured=1` to the `{{Assessments}}` template.  That’s astonishing because the method `Candidate.addAssessments()` contains code which deals with exactly that case.  Just reducing the indentation level of the last line `self.commit(...)` fixes this.  That line must be applied regardless whether there is already an `{{Assessments}}` template or not, else the prepared changes are just not committed.

2. After fixing the first bug another one becomes obvious.  The method contains two lines which should remove already existing `featured=...` or `com-nom=...` parameters from the `{{Assessments}}` template, but they do not work if the parameter is the first one in the template.  Why?  Both lines assume that the parameter is preceded by a `|`, but the regex which extracts the parameters does not capture the `|` before the first parameter.  We can fix this simply by moving the `\|` into the capturing parentheses of the regex, i.e., replacing `\|(.*)` by `(\|.*)`.

3. While we are at it we can also make that regex more foolproof.  I have seen people putting several templates (even completely unrelated ones) on a single line.  If somebody would put a template on the same line right after the `{{Assessments}}` template, the `.*` would cheerfully capture not only the parameters, but also the `}}` and the complete next template until its `}}`, and that would make the results of the following code invalid.  OK, this is a rather unlikely problem, but I have seen people creating such Wikitext lines, and we can simply handle this by just making the greedy `*` quantifier non-greedy: `(\|.*?)` fixes this.

4. To be on the save side let’s properly escape the leading `{{` and trailing `}}` in the regex.  Yes, the regex works as it is, but normally every literal `{` and `}` in a regex should be escaped, and currently it depends on the regex engine and maybe even on its version whether the regex works without the escapes or not.


### Tweak and simplify some minor points in the code of that method

1. We do not need to create an empty list first and then append an entry to it, we can just define a list with that single entry.

2. Both people reading the code and linters/type checkers may stumble over the double use of the local variable `params`; unlike its name suggests, it is first used for the complete result of the `re.search()` call which is either a `re.Match` object or `None`.  Using two variables, `match` and `params`, makes the code clearer and avoids any misunderstandings.

3. While the previous change may appear pedantic, it has the advantage that it allows us to drop the repeated regex search: we can simply use the position values `match.start(0)` and `match.end(0)` from the first search to construct the new text with the new version of the `{{Assessments}}` template.

4. We can apply the first TODO comment and remove the support for the old `com=…` parameter: a search shows that not a single featured picture still contains the `com=…` parameter.  (But we must not remove the support for the `subpage=…` parameter: a search shows there are still ~ 1.871 featured pictures which use that variant of the parameter.)

5. Instead of searching for the first occurrence of `|` in `params` and checking if its position is `!= 0`, we can just test `if params[0] != "|"`.

6. The commented line `# new_text = re.sub(r'({{\s*[Ii]nformation)',...` can and should be removed.  The existing code above it which calls `findEndOfTemplate()` works well and is much better, so the commented code is just confusing and should go.

7. We need to compile the regex `AssR` just once.

I have written a test script which applies both the current and the proposed new code to the Wikitext of a whole list of (potential) FPs with and without `{{Assessments}}` template and then compares the results. In all cases in which the current code works properly the new one returns the same results; in all cases in which the current code fails to update the `{{Assessments}}` template the new code works correctly. So the danger of unwanted side-effects and regressions should be low.