### PR TITLE
Polish file docstring, add shebang, sort imports

### DIFF
--- a/fpc.py
+++ b/fpc.py
@@ -1,31 +1,41 @@
+#!/usr/bin/env python3
 """
-This bot runs as FPCBot on wikimedia commons
-It implements vote counting and supports bot runs as FPCBot on wikimedia commons
-It implements vote counting and supports
-moving the finished nomination to the archive.
+This script runs as FPCBot on Wikimedia Commons.
+It counts the votes in featured picture nominations,
+closes and archives finished nominations,
+informs uploaders and nominators about the success
+and adds newly promoted featured pictures to the gallery pages.
 
 Programmed by Daniel78 at Commons.
 
-It adds the following commandline arguments:
+Command line options:
 
--test             Perform a testrun against an old log
--close            Close and add result to the nominations
--info             Just print the vote count info about the current nominations
--park             Park closed and verified candidates
--auto             Do not ask before commiting edits to articles
--dry              Do not submit any edits, just print them
--threads          Use threads to speed things up, can't be used in interactive mode
--fpc              Handle the featured candidates (if neither -fpc or -delist is used all candidates are handled)
--delist           Handle the delisting candidates (if neither -fpc or -delist is used all candidates are handled)
--notime           Avoid displaying timestamps in log output
--match pattern    Only operate on candidates matching this pattern
+-test           Perform a testrun against an old log.
+-close          Close and add results to the nominations.
+-info           Just print the vote count info about the current nominations.
+-park           Park closed and verified candidates.
+-auto           Do not ask before commiting edits to articles.
+-dry            Do not submit any edits, just print them.
+-threads        Use threads to speed things up
+                (can't be used in interactive mode).
+-fpc            Handle the featured candidates (if neither -fpc
+                nor -delist is used all candidates are handled).
+-delist         Handle the delisting candidates (if neither -fpc
+                nor -delist is used all candidates are handled).
+-notime         Avoid displaying timestamps in log output.
+-match pattern  Only operate on candidates matching this pattern.
 """
 
-import pywikibot, re, datetime, sys, signal
+# Standard library imports
+import sys
+import signal
+import datetime
+import time
+import re
+import threading
 
-
-# Imports needed for threading
-import threading, time
+# Third-party imports
+import pywikibot
 from pywikibot import config
 
 


### PR DESCRIPTION
Let’s tidy up and polish the “preamble” of the script – after all FPCBot is not a quick hack, but a distinguished bot, so it deserves a neat and tidy file docstring etc.

1. Let’s add the usual shebang line.  It indicates that this file is not a library etc., but can and should be run as a script; it makes clear that this is a Python 3 script; it allows to run the script directly via `./fpc.py`.  If you know any reasons why this file should *not* have a shebang line (I was not able to find such reasons), sorry, please drop this part of the commit.

2. In the file docstring some text is repeated and has got in a muddle.  Let’s fix this and also explain a little bit better what this script does.

3. The long lines of the command line options in the docstring often display quite untidy in the terminal. We can easily fix this by breaking the lines.

4. PEP 8 recommends to put import statements on separate lines and to sort them so that imports from the standard library form a first group and imports of third-party packages a second group.  This is useful for us, too.

Of course these changes are banal, but they may very well help to make the code a little bit more inviting to potential new developers.  And we need new developers.  This is why I make not only pull requests for bug fixes (more of them are on their way), but also little polishing campaigns like this one.