### PR TITLE
Make the -dry option work

### DIFF
--- a/fpc.py
+++ b/fpc.py
@@ -1828,7 +1828,7 @@ def main(*args):
             "-dry",
         }:
             out(
-                "Warning - unknown argument '%s' aborting, see -help." % arg,
+                "Warning - unknown argument '%s'; aborting, see -help." % arg,
                 color="lightred",
             )
             sys.exit(0)


### PR DESCRIPTION
The `-dry` option is an excellent test tool, but it does not work: if you use it the script exits with the message

> Warning - unknown argument '-dry' aborting, see -help.

Adding the option to the allowed argument values fixes this.  At this opportunity I propose to use a set instead of a list for the allowed options, IMHO this is more idiomatic Python and makes clear that the order of entries does not matter here.

As a little follow-up, let’s make the cited warning about an unknown argument a little bit easier to understand; just inserting a semicolon helps a lot.