### PR TITLE
Improve extraction of filenames

### DIFF
--- a/fpc.py
+++ b/fpc.py
@@ -525,7 +525,7 @@ class Candidate:
 
     def cutTitle(self):
         """Returns a fixed width title."""
-        return re.sub(PrefixR, "", self.page.title())[0:50].ljust(50)
+        return PrefixR.sub("", self.page.title())[0:50].ljust(50)
 
     def cleanTitle(self, keepExtension=False):
         """
@@ -534,11 +534,11 @@ class Candidate:
         a possible change by the alternative parameter is not considered,
         but maybe it should be ?
         """
-        noprefix = re.sub(PrefixR, "", self.page.title())
+        noprefix = PrefixR.sub("", self.page.title())
         if keepExtension:
             return noprefix
         else:
-            return re.sub(r"\.\w{1,3}$\s*", "", noprefix)
+            return re.sub(r"\.\w{2,4}\s*$", "", noprefix)
 
     def fileName(self, alternative=True):
         """
@@ -548,17 +548,14 @@ class Candidate:
         Will return the new file name if moved.
         @param alternative if false disregard any alternative and return the real filename
         """
-        # The regexp here also removes any possible crap between the prefix
-        # and the actual start of the filename.
         if alternative and self._alternative:
             return self._alternative
 
         if self._fileName:
             return self._fileName
 
-        self._fileName = re.sub(
-            "(%s.*?)([Ff]ile|[Ii]mage)" % candPrefix, r"\2", self.page.title()
-        )
+        # Remove nomination page prefix and use standard 'File:' namespace
+        self._fileName = PrefixR.sub("File:", self.page.title())
 
         if not pywikibot.Page(G_Site, self._fileName).exists():
             match = re.search(ImagesR, self.page.get(get_redirect=True))
@@ -1046,7 +1043,7 @@ class Candidate:
         except pywikibot.exceptions.NoPageError:
             old_log_text = ""
 
-        if re.search(wikipattern(self.fileName()), old_log_text):
+        if re.search(wikipattern(self.page.title()), old_log_text):
             out(
                 "Skipping add in moveToLog for '%s', page already there"
                 % self.cleanTitle(),
@@ -1657,10 +1654,13 @@ keep_templates = (
 # Compiled regular expressions follows
 #
 
-# Used to remove the prefix and just print the file names
-# of the candidate titles.
+# Used to remove the nomination page prefix and the 'File:'/'Image:' namespace
+# or to replace both by the standard 'File:' namespace.
+# Removes also any possible crap between the prefix and the namespace
+# and faulty spaces between namespace and filename (sometimes users
+# accidentally add such spaces when creating nominations).
 candPrefix = "Commons:Featured picture candidates/"
-PrefixR = re.compile("%s.*?([Ff]ile|[Ii]mage)?:" % candPrefix)
+PrefixR = re.compile(candPrefix + r".*?([Ff]ile|[Ii]mage): *")
 
 # Looks for result counts, an example of such a line is:
 # '''result:''' 3 support, 2 oppose, 0 neutral => not featured.


### PR DESCRIPTION
Several methods of the `Candidate` class try to extract the image filename from the name of a nomination subpage:

* `fileName()` is the most general method, it just removes the prefix ‘Commons:Featured picture candidates/’
(it also does some other things which are not of concern here).

* `cleanTitle()` also removes the leading ‘File:’ or ‘Image:’ namespace prefix and optionally also the file extension.

* `cutTitle()` also cuts the filename to a fixed length in order to allow pretty printing.

The output of these methods is used to retrieve the image description page, to print messages and to generate entries on the featured picture gallery pages and in log files. This commit fixes some minor issues and increases the consistency of the output of these methods.

1. The ‘Image:’ namespace prefix is obsolete.  Some users still use ‘Image:’ when creating a nomination, but it seems odd if in 2025 the bot still happily copies it and adds new ‘Image:...’ entries to the gallery pages.  Let’s get rid of it and make `fileName()` always use the ‘File:’ prefix for output. This does not only make our gallery pages more consistent, it also can help to avoid problems in the script itself. E.g. the method `Candidate.addAssessments()` assumes that the image filename starts with ‘File:’ when it assembles the `com-nom` parameter; if it starts with ‘Image:’, the method can’t remove that prefix and therefore adds it inadvertently to the `com-nom` parameter for the `{{Assessments}}` template. That does not work: the template can’t handle the prefix and displays an error message instead of the nomination link.

2. Sometimes nominators put spaces between the namespace prefix and the actual filename, e.g. ‘File: Test.jpg’.  Don’t ask me why, but it happens again and again.  I have often fixed this by hand. This space does *not* belong to the filename, it only occurs in the name of the nomination.  Therefore the bot should not copy these spaces when creating gallery page entries etc., but currently it does.  We can get rid of the space(s) by appending a simple ` *` to the `PrefixR` regex.

3. We can reuse the precompiled regex `PrefixR` in `fileName()` instead of defining there another, practically equivalent regex.

4. The regex which is used by `cleanTitle()` to remove the file extension handles only one- to three-letter suffixes. But we must also handle ‘.jpeg’, ‘.tiff’ or ‘.webp’ files. The old code does not do this, therefore it adds ugly stuff like ‘xxx.tiff’ as caption to the featured picture gallery pages. We just need to change that part of the regex from `\w{1,3}` to `\w{1,4}`.  But is there an image file format which is supported by Wikimedia Commons and uses a one-letter extension? I can’t find such a file format, so let’s use `\w{2,4}` instead; probably we can even enforce this later to `\w{3,4}`.

5. This regex ends with `...$\s*`.  This looks like a little typo. We are not in `re.MULTILINE` mode, therefore the `$` matches only at the end of the string, there can’t be any whitespace after it. If we want to catch and remove whitespace after the file extension, let’s change the regex to `...\s*$`.

6. I propose to put the constant `candPrefix` with a simple `+` at the beginning of the `PrefixR` pattern; that’s boring, yes, but IMHO it’s easier to understand than starting the regex with `r"%s...` and replacing the `%s` by a postponed `... % candPrefix`. Using `+` puts the constant at the beginning where it belongs.

7. In `Candidate.moveToLog()` the old code searches the log of closed nominations for the filename in order to determine whether the nomination subpage has already been added or not. For this task it seems more appropriate and reliable to search for the actual name of the nomination subpage, and after the changes in this commit (which replace any ‘Image:’ prefix with ‘File:’ and remove false spaces) this is necessary now.

I have written a test script which applies both the old and the new version of these methods to all 3108 nominations made between January 2024 and April 2025.
The results differ in 17 cases: in 7 cases the old code can’t handle a 4-letter file extensions correctly, the new code can; in 5 cases the old code copied the obsolete ‘Image:’ prefix, the new code replaces it by ‘File:’; in 4 cases users have put spaces between the prefix and the filename, the new code drops these spaces.  And there is one special case, the nomination

[[Commons:Featured picture candidates/removal/
Category:Featured pictures by User:Diliff]]

Here the old code happily treats the name like a normal filename; this would have led to strange results if the removal nomination would have been successful.  The new code just does not change the name of that nomination at all; that’s more appropriate because even if that nomination would have been successful, it would have be necessary to carry it out completely manually.