### PR TITLE
Update keyword arg for Pywikibot BasePage.getReferences()

### DIFF
--- a/fpc.py
+++ b/fpc.py
@@ -1309,8 +1309,7 @@ class DelistCandidate(Candidate):
         # the chance that we are there is very small and even
         # if we are we will soon be rotated away anyway.
         # So just check and remove the candidate from any gallery pages
-
-        references = self.getImagePage().getReferences(withTemplateInclusion=False)
+        references = self.getImagePage().getReferences(with_template_inclusion=False)
         for ref in references:
             if ref.title().startswith("Commons:Featured pictures/"):
                 if ref.title().startswith("Commons:Featured pictures/chronological"):


### PR DESCRIPTION
The Pywikibot method `BasePage.getReferences()` does not have a keyword argument `withTemplateInclusion` anymore, according to [the documentation for Pywikibot 10.0](https://doc.wikimedia.org/pywikibot/stable/api_ref/pywikibot.page.html#page.BasePage.getReferences) the argument is called `with_template_inclusion` now.