### PR TITLE
Fix uncaught SectionError when a nomination redirects to a section

### DIFF
--- a/fpc.py
+++ b/fpc.py
@@ -3994,6 +3994,24 @@ def _resolve_nomination_subpage_redirect(
                 f"contains an invalid redirect. {PLEASE_FIX_HINT}"
             )
             return None
+        # A nomination subpage must redirect to a whole page, never to a
+        # section.  A malformed "#REDIRECT [[Target#Section]]" yields a
+        # target that still carries the section on pywikibot versions before
+        # 9.3, which added the 'ignore_section' parameter to
+        # getRedirectTarget().  Calling Page.get() on such a target later
+        # raises an uncaught SectionError and aborts the whole bot run.
+        # Treat a redirect that points to a section as invalid instead.
+        if subpage.section():
+            error(
+                f"Error - nomination redirect '{old_name}' points to a "
+                "section, ignoring."
+            )
+            ask_for_help(
+                f"The nomination subpage [[{old_name}]] redirects to a "
+                "section of a page rather than to a page itself, "
+                f"which the bot cannot process. {PLEASE_FIX_HINT}"
+            )
+            return None
         new_name = subpage.title()
         out(f"Nomination '{old_name}' has been renamed to '{new_name}'")
         redirects.append((old_name, new_name))


### PR DESCRIPTION
## Problem

FPCBot crashed with an uncaught `SectionError`, aborting the entire run:

```
pywikibot.exceptions.SectionError: 'File:A polarized light micrograph of physiological saline crystals.jpg' is not a valid section of Commons:Featured picture candidates/File:A polarized light micrograph of physiological saline crystals.jpg
```

(reported by FPCBot on the FPC talk page, 6 June 2026).

## Root cause

The nomination subpage was a redirect pointing to a **section** (a malformed `#REDIRECT [[Target#Section]]`). In `_resolve_nomination_subpage_redirect()`, `subpage.getRedirectTarget()` returned a `Page` that still carried that section fragment: the `ignore_section` parameter (which by default strips the section from the target) was only added to `getRedirectTarget()` in **pywikibot 9.3**. The candidate's page therefore had a section, and the later `Page.get()` (reached via `filtered_content()` → `was_cancelled()` during `park`) raised the uncaught `SectionError`.

## Fix

A nomination subpage must redirect to a whole page, never to a section. The fix detects a redirect whose resolved target carries a section and treats it as an invalid redirect: it skips the nomination and reports it via `ask_for_help()`, consistently with how other invalid redirects are already handled. It uses only `Page.section()`, so it is independent of the pywikibot version.

## Testing

- Reproduced the exact `SectionError` offline (constructing a `Page` with the section fragment raises it in `Page.get()`, before any network call).
- Unit-tested `_resolve_nomination_subpage_redirect()`:
  - a redirect pointing to a section is now skipped (`return None`) and flagged via `ask_for_help()`, instead of crashing the run;
  - a normal rename redirect (target without a section) still resolves correctly and records the rename.
- `python -m py_compile fpc.py` passes.

